### PR TITLE
Enable Python 3.14 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "conda-self" %}
 {% set version = "0.1.1" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set sha256 = "79133aa60a43eec1783aeef63abe7df3ac17c1dfed95398bf0de2315b7d735cf" %}
 
 package:


### PR DESCRIPTION
conda-self 0.1.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/conda-incubator/conda-self)

### Explanation of changes:

- Add `abs.yaml` with `ANACONDA_ROCKET_ENABLE_PY314: yes` to build conda-self for Python 3.14
- Bump build number to 1 to trigger a rebuild with the new Python variant
- Add `!/abs.yaml` to `.gitignore` so the file is tracked (conda-smithy's default ignores everything)